### PR TITLE
Fixed example to avoid `panic: ERROR: flag description does not exist [recovered]'.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -18,6 +18,7 @@ func ExampleResolve() {
 	flagSet := flag.NewFlagSet("example", flag.ExitOnError)
 	flagSet.Int64("max-size", 1024768, "maximum size")
 	flagSet.Duration("timeout", 1*time.Hour, "timeout setting")
+	flagSet.String("description", "", "description info")
 	// parse command line arguments here
 	// flagSet.Parse(os.Args[1:])
 	flagSet.Parse([]string{"-timeout=5s"})


### PR DESCRIPTION
In tracking down another issue (which I'll submit another PR for), I noticed that the example code doesn't actually work.

The inclusion of the `flag:"description"` tag without a corresponding `flagSet.X("descrioption", ...)` defined results in a panic during `Resolve(...)`.