### PR TITLE
Fixed `options.Resolve' function behavior WRT default flag values

### DIFF
--- a/options.go
+++ b/options.go
@@ -79,14 +79,14 @@ func Resolve(options interface{}, flagSet *flag.FlagSet, cfg map[string]interfac
 			v = deprecatedFlag.Value.String()
 			log.Printf("WARNING: use of the --%s command line flag is deprecated (use --%s)",
 				deprecatedFlagName, flagName)
-		} else {
-			cfgVal, ok := cfg[cfgName]
-			if !ok {
-				// if the config file option wasn't specified just use the default
-				continue
-			}
+		} else if cfgVal, ok := cfg[cfgName]; ok {
 			v = cfgVal
+		} else {
+			// if no flag arg or config file option was specified just use the default
+			// flag value
+			v = flagInst.Value.(flag.Getter).Get()
 		}
+
 		fieldVal := val.FieldByName(field.Name)
 		coerced, err := coerce(v, fieldVal.Interface(), field.Tag.Get("arg"))
 		if err != nil {

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,32 @@
+package options_test
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/jaytaylor/go-options"
+)
+
+// TestFlagSetDefaults verifies that default flag values are applied in the
+// absence of user-specified setting.
+func TestFlagSetDefaults(t *testing.T) {
+	flagSet := flag.NewFlagSet("TestFlagSetDefaults", flag.PanicOnError)
+
+	flagSet.Int64("max-size", 1024768, "maximum size")
+	flagSet.Duration("timeout", 1*time.Hour, "timeout setting")
+	flagSet.String("description", "", "description info")
+
+	if err := flagSet.Parse([]string{"-timeout=5s"}); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &Options{}
+	cfg := map[string]interface{}{}
+
+	options.Resolve(opts, flagSet, cfg)
+
+	if expected, actual := flagSet.Lookup("max-size").Value.(flag.Getter).Get().(int64), opts.MaxSize; actual != expected {
+		t.Errorf("Expected opts.MaxSize to default to %v but actual=%v", expected, actual)
+	}
+}


### PR DESCRIPTION
Fixed `options.Resolve' function behavior to fall back to using the default
`flag.Value' when no flagSet arg or cfg value is available.

Includes corresponding unit-test.

    $ go test -v ./...
    === RUN   TestFlagSetDefaults
    --- PASS: TestFlagSetDefaults (0.00s)
    PASS
    ok  	github.com/jaytaylor/go-options	0.005s
