### PR TITLE
Jay/fix ignored cfg values

### DIFF
--- a/options.go
+++ b/options.go
@@ -71,6 +71,7 @@ func Resolve(options interface{}, flagSet *flag.FlagSet, cfg map[string]interfac
 		// 1. command line flag
 		// 2. deprecated command line flag
 		// 3. config file option
+		// 4. default flag value
 		var v interface{}
 		if hasArg(flagName) {
 			v = flagInst.Value.String()
@@ -270,8 +271,11 @@ func coerce(v interface{}, opt interface{}, arg string) (interface{}, error) {
 }
 
 func hasArg(s string) bool {
+	if !strings.HasPrefix(s, "-") {
+		s = "-" + s
+	}
 	for _, arg := range os.Args {
-		if strings.Contains(arg, s) {
+		if strings.Split(arg, "=")[0] == s {
 			return true
 		}
 	}


### PR DESCRIPTION
I found a quite unexpected bug where I was running an app like so:

    ./server -server

Where `-server` is a boolean flag.  It worked fine in all cases except when "server=true" was specified in a TOML config, e.g. command line:

    ./server -config some/file.tml

In the above case the `server=true` value was being ignored due to the `hasArgs` function using too lax of a wildcard-style search on `os.Args`.  It was picking up "server" from the binary name and then interpreting the match to mean the flag had been specified on the command line! (when it was actually absent)

----
Commit message:

Fixed config values being ignored when anything matching the wildcard pattern
*flag-name* is found in os.Args.

Includes corresponding unit-test.

----
Test run of failing case before:

    === RUN   TestConfigWithOverlappingOsArgs
    --- FAIL: TestConfigWithOverlappingOsArgs (0.00s)
    	options_test.go:72: Expected opts.Server=true but actual=false

Test run of failing case after:

    === RUN   TestConfigWithOverlappingOsArgs
    --- PASS: TestConfigWithOverlappingOsArgs (0.00s)

----
Sidenote: Hopefully this PR won't break downstream package users like that first one, but if they are relying on this broken behavior.. it's hard to have much sympathy for them :)  Let's get it fixed!