### PR TITLE
Skip the first os.Args when iterating

### DIFF
--- a/options.go
+++ b/options.go
@@ -276,7 +276,7 @@ func hasArg(s string) bool {
 	if !strings.HasPrefix(s, "-") {
 		s = "-" + s
 	}
-	for _, arg := range os.Args {
+	for _, arg := range os.Args[1:] {
 		if strings.Split(arg, "=")[0] == s {
 			return true
 		}


### PR DESCRIPTION
This will always be the program name, so no point checking it

Micro-optimization here. :)