### PR TITLE
remove odd debug log of []float64

### DIFF
--- a/options.go
+++ b/options.go
@@ -210,7 +210,6 @@ func coerceFloat64Slice(v interface{}) ([]float64, error) {
 			tmp = append(tmp, f)
 		}
 	case []float64:
-		log.Printf("%+v", v)
 		tmp = v.([]float64)
 	}
 	return tmp, nil


### PR DESCRIPTION
I noticed this in the nsqd startup log messages:

```
$ ./build/nsqd 
2016/12/29 13:55:41 []
[nsqd] 2016/12/29 13:55:41.380230 nsqd v0.3.8 (built w/go1.7.4)
[nsqd] 2016/12/29 13:55:41.380238 ID: 602
[nsqd] 2016/12/29 13:55:41.380332 NSQ: persisting topic/channel metadata to nsqd.602.dat
```