### PR TITLE
update .travis.yml to Go 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
+  - 1.x
 notifications:
   email: false
 sudo: false

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Resolve configuration values set via command line flags, config files, and default struct values.
 
-[![Build Status](https://travis-ci.org/mreiferson/go-options.svg?branch=master)](https://travis-ci.org/mreiferson/go-options) [![GoDoc](https://godoc.org/github.com/mreiferson/go-options?status.svg)](https://godoc.org/github.com/mreiferson/go-options)
+[![Build Status](https://secure.travis-ci.org/mreiferson/go-options.png?branch=master)](http://travis-ci.org/mreiferson/go-options) [![GoDoc](https://godoc.org/github.com/mreiferson/go-options?status.svg)](https://godoc.org/github.com/mreiferson/go-options) [![GitHub release](https://img.shields.io/github/release/mreiferson/go-options.svg)](https://github.com/mreiferson/go-options/releases/latest)


### PR DESCRIPTION
It's probably time for a 1.0.0 release on this package (I'm working my way through cleaning up versions for everyting nsq uses as dependencies)